### PR TITLE
Check if DS is already defined

### DIFF
--- a/src/Ubiquity
+++ b/src/Ubiquity
@@ -618,6 +618,8 @@ class Ubiquity {
 }
 error_reporting(E_ALL);
 
-define('DS', DIRECTORY_SEPARATOR);
+if (!defined('DS')) {
+    define('DS', DIRECTORY_SEPARATOR);
+}
 
 Ubiquity::init(@$argv[1]);


### PR DESCRIPTION
When using in the global composer, it possible some other package already defined DS as DIRECTORY_SEPARATOR.
PHP is giving a vage notice about this.