### PR TITLE
[WIP] Removed double defined ROOT

### DIFF
--- a/src/Ubiquity
+++ b/src/Ubiquity
@@ -281,7 +281,6 @@ class Ubiquity {
 
 	private static function selfUpdate(){
 		self::_init();
-		define('ROOT', realpath('./app').DS);
 		echo ConsoleFormatter::showInfo("Files copy...\n");
 
 		$filename="app/controllers/Admin.php";


### PR DESCRIPTION
This is just my guess.
The ROOT is already defined in the _init() so no point in setting it again and getting a PHP notice.
https://github.com/phpMv/ubiquity-devtools/blob/8fefc035a01b07a268e695ce08b3afba2fcb5fe0/src/Ubiquity#L603

