### PR TITLE
Do not try to use Ubiquity if vendors are not installed

### DIFF
--- a/src/Ubiquity
+++ b/src/Ubiquity
@@ -169,21 +169,23 @@ class Ubiquity {
 				foreach ($vendorCopies as $theme=>$vCopies){
 					InstallThemeCmd::copyVendorFiles($theme, $vCopies, $dir);
 				}
-			}
-			$config=require_once 'app/config/config.php';
-			\Ubiquity\controllers\Startup::setConfig($config);
+				$config=require_once 'app/config/config.php';
+				\Ubiquity\controllers\Startup::setConfig($config);
 
-			if(self::isBooleanTrue(self::$configOptions["%all-models%"])){
+				if(self::isBooleanTrue(self::$configOptions["%all-models%"])){
+					ob_start();
+					(new \Ubiquity\orm\creator\database\DbModelsCreator())->create($config);
+					$res=ob_get_clean();
+					echo ConsoleFormatter::showMessage($res,'success','models generation');
+				}
 				ob_start();
-				(new \Ubiquity\orm\creator\database\DbModelsCreator())->create($config);
+				\Ubiquity\cache\CacheManager::checkCache($config);
 				$res=ob_get_clean();
-				echo ConsoleFormatter::showMessage($res,'success','models generation');
+				echo ConsoleFormatter::showMessage($res,'info','cache initialization');
+				echo ConsoleFormatter::showMessage("project <b>{$projectName}</b> successfully created.",'success','new-project');
+			} else {
+				echo ConsoleFormatter::showMessage("Project <b>{$projectName}</b> is partialy created.\nYou will need to run `composer install` in the root folder of the project.\nThen `Ubiquity init-cache` to initialize the cache folders.\n",'info');
 			}
-			ob_start();
-			\Ubiquity\cache\CacheManager::checkCache($config);
-			$res=ob_get_clean();
-			echo ConsoleFormatter::showMessage($res,'info','cache initialization');
-			echo ConsoleFormatter::showMessage("project <b>{$projectName}</b> successfully created.",'success','new-project');
 		}else{
 			echo ConsoleFormatter::showInfo("The <b>{$projectName}</b> folder already exists !\n");
 			$answer=Console::question("Would you like to continue ?",["y","n"]);


### PR DESCRIPTION
Hi there,

This PR fix an error occurring during creation of a project if the user do not wish to install composer dependencies.

After asking for dependencies installation, the process will try to generate models / cache folders but can't access required classes as they are part of the main Ubiquity repo.

The problem doesn't exist if Ubiquity is globally installed (no valid reason tho, ubiquity-devtools exists for this purpose).

What this PR do :
- Tried to fix this as simply as possible without any broken changes.
- Added an informational message in case user do not install composer dependencies.

What this PR **don't** do :
- Updated the package version (I'm unsure where / how change it)

---------

To dig deeper in this problem, I've come to the following reflection : 
"Why do we ask user if he want to install composer dependencies if this break the installer ?"

I checked Laravel Installer (https://github.com/laravel/installer) and they don't let you the choice of installing dependencies as they are required for the application to run.

If you guys are ok, I can close this PR and create another one removing the question about dependencies and install them in any case.
What do you think ?

Tantriss.